### PR TITLE
Use the right type of infinity so we don't get a compiler warning.

### DIFF
--- a/cuBQL/queries/pointData/findClosest.h
+++ b/cuBQL/queries/pointData/findClosest.h
@@ -46,7 +46,7 @@ namespace cuBQL {
                     /*! square of the maximum query distance in which
                       this query is to look for candidates. note
                       this is the SQUARE distance */
-                    float squareOfMaxQueryDistance=INFINITY);
+                    float squareOfMaxQueryDistance=PosInfTy());
 
     /*! given a (W-wide) bvh build over a set of float<N> points,
       perform a closest-point query that returns the index of the
@@ -77,7 +77,7 @@ namespace cuBQL {
                     /*! square of the maximum query distance in which
                       this query is to look for candidates. note
                       this is the SQUARE distance */
-                    float squareOfMaxQueryDistance=INFINITY);
+                    float squareOfMaxQueryDistance=PosInfTy());
 
 
     template<typename T, int D>
@@ -95,7 +95,7 @@ namespace cuBQL {
                              /*! square of the maximum query distance in which
                                this query is to look for candidates. note
                                this is the SQUARE distance */
-                             float squareOfMaxQueryDistance=INFINITY);
+                             float squareOfMaxQueryDistance=PosInfTy());
     
     template<typename T, int D>
     /*! same as regular points::closestPoint, but excluding all data
@@ -112,7 +112,7 @@ namespace cuBQL {
                                /*! square of the maximum query distance in which
                                  this query is to look for candidates. note
                                  this is the SQUARE distance */
-                               float squareOfMaxQueryDistance=INFINITY);
+                               float squareOfMaxQueryDistance=PosInfTy());
 
 #ifdef __CUDACC__
     // ******************************************************************
@@ -128,7 +128,7 @@ namespace cuBQL {
                     /*! square of the maximum query distance in which
                       this query is to look for candidates. note
                       this is the SQUARE distance */
-                    float squareOfMaxQueryDistance=INFINITY);
+                    float squareOfMaxQueryDistance=PosInfTy());
 
     // ******************************************************************
     /*! variant of cuBQL::point::findClosest() that's specialized for
@@ -143,7 +143,7 @@ namespace cuBQL {
                     /*! square of the maximum query distance in which
                       this query is to look for candidates. note
                       this is the SQUARE distance */
-                    float squareOfMaxQueryDistance=INFINITY);
+                    float squareOfMaxQueryDistance=PosInfTy());
 
     // ******************************************************************
     /*! variant of cuBQL::point::findClosest() that's specialized for
@@ -158,7 +158,7 @@ namespace cuBQL {
                     /*! square of the maximum query distance in which
                       this query is to look for candidates. note
                       this is the SQUARE distance */
-                    float squareOfMaxQueryDistance=INFINITY);
+                    float squareOfMaxQueryDistance=PosInfTy());
 #endif
     
     // ******************************************************************
@@ -179,7 +179,7 @@ namespace cuBQL {
                                   /*! square of the maximum query distance in which
                                     this query is to look for candidates. note
                                     this is the SQUARE distance */
-                                  float squareOfMaxQueryDistance=INFINITY)
+                                  float squareOfMaxQueryDistance=PosInfTy())
     {
       int closestID = -1;
       float closestSqrDist = squareOfMaxQueryDistance;
@@ -227,7 +227,7 @@ namespace cuBQL {
                                   /*! square of the maximum query distance in which
                                     this query is to look for candidates. note
                                     this is the SQUARE distance */
-                                  float squareOfMaxQueryDistance=INFINITY)
+                                  float squareOfMaxQueryDistance=PosInfTy())
     {
       int closestID = -1;
       float closestSqrDist = squareOfMaxQueryDistance;

--- a/cuBQL/queries/pointData/knn.h
+++ b/cuBQL/queries/pointData/knn.h
@@ -52,7 +52,7 @@ namespace cuBQL {
                                /*! square of the maximum query distance in which
                                  this query is to look for candidates. note
                                  this is the SQUARE distance */
-                               float squareOfMaxQueryDistance=INFINITY);
+                               float squareOfMaxQueryDistance=PosInfTy());
     
     
     // ******************************************************************

--- a/cuBQL/queries/triangleData/math/boxTriangleIntersections.h
+++ b/cuBQL/queries/triangleData/math/boxTriangleIntersections.h
@@ -85,7 +85,7 @@ namespace cuBQL {
            entirely within that slab (iff lower_k <= a_k <= upper_k),
            or entirely outside */
         if (a_k > upper_k || a_k < lower_k) {
-          t0 = INFINITY; t1 = -INFINITY;
+          t0 = PosInfTy(); t1 = -PosInfTy();
         }
       } else {
         /* line segment is not parallel to the slab planes, so we can

--- a/cuBQL/queries/triangleData/math/pointToTriangleDistance.h
+++ b/cuBQL/queries/triangleData/math/pointToTriangleDistance.h
@@ -15,7 +15,7 @@ namespace cuBQL {
 
     struct PointToTriangleTestResult {
       /*! (square!) distance between query point and closest point on triangle.*/
-      float sqrDist = INFINITY;
+      float sqrDist = PosInfTy();
       /*! the actual 3D point that's closest on the triangle */
       vec3f P;
     };


### PR DESCRIPTION
Depending on the windows toolkit being used on Windows (and maybe whatever #defines are set?) we can get compiler warnings like:
```
cuBQL/queries/pointData/findClosest.h(161): error #221-D: floating-point value does not fit in required floating-point type
                      float squareOfMaxQueryDistance=((float)(1e+300)));
                                                      ^
```

This happens because INFINITY can be defined by Windows toolkit to be 1e300:
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\ucrt\corecrt_math.h
```
#ifndef _HUGE_ENUF
    #define _HUGE_ENUF  1e+300  // _HUGE_ENUF*_HUGE_ENUF must overflow
#endif
#ifndef _UCRT_LEGACY_INFINITY
#define INFINITY   ((float)(_HUGE_ENUF))
```

cubql already has functions to do this properly, so I went ahead and used that.